### PR TITLE
Using meta-data instead of BuildConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,48 +17,18 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField "String", "CLIENT_ID", "\"" + getGHId(false) + "\""
-            buildConfigField "String", "CLIENT_SECRET", "\"" + getGHSecret(false) + "\""
-            buildConfigField "String", "CLIENT_CALLBACK", "\"" + getGHCallback(false) + "\""
         }
         release {
-            buildConfigField "String", "CLIENT_ID", "\"" + getGHId(true) + "\""
-            buildConfigField "String", "CLIENT_SECRET", "\"" + getGHSecret(true) + "\""
-            buildConfigField "String", "CLIENT_CALLBACK", "\"" + getGHCallback(true) + "\""
         }
-    }
-}
-
-def getGHId(pro) {
-    if (pro) {
-        return hasProperty('GH_PRO_ID') ? GH_PRO_ID : System.getenv('GH_PRO_ID')
-    } else {
-        return hasProperty('GH_DEV_ID') ? GH_DEV_ID : System.getenv('GH_DEV_ID')
-    }
-}
-
-def getGHSecret(pro) {
-    if (pro) {
-        return hasProperty('GH_PRO_SECRET') ? GH_PRO_SECRET : System.getenv('GH_PRO_SECRET')
-    } else {
-        return hasProperty('GH_DEV_SECRET') ? GH_DEV_SECRET : System.getenv('GH_DEV_SECRET')
-    }
-}
-
-def getGHCallback(pro) {
-    if (pro) {
-        return hasProperty('GH_PRO_CALLBACK') ? GH_PRO_CALLBACK : System.getenv('GH_PRO_CALLBACK')
-    } else {
-        return hasProperty('GH_DEV_CALLBACK') ? GH_DEV_CALLBACK : System.getenv('GH_DEV_CALLBACK')
     }
 }
 
 dependencies {
 
-    compile 'com.android.support:support-annotations:21.0.3'
+    compile 'com.android.support:support-annotations:22.2.0'
 
     compile 'net.danlew:android.joda:2.6.0'
     compile 'org.ocpsoft.prettytime:prettytime:3.2.4.Final'
 
-    compile project(':sdks:BaseSDK')
+    compile 'com.github.Meisolsson:BaseSDK:a81d3e4934'
 }

--- a/src/main/java/com/alorma/github/sdk/security/GitHub.java
+++ b/src/main/java/com/alorma/github/sdk/security/GitHub.java
@@ -1,25 +1,52 @@
 package com.alorma.github.sdk.security;
 
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
 import com.alorma.github.sdk.BuildConfig;
 import com.alorma.gitskarios.basesdk.ApiClient;
+
+import java.util.Collection;
 
 /**
  * Created by Bernat on 08/07/2014.
  */
 public class GitHub implements ApiClient {
+
+    private String API_CLIENT;
+    private String API_SECRET;
+    private String API_OAUTH;
+
+    public GitHub(Context context){
+        try {
+            ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            Bundle bundle = ai.metaData;
+            API_CLIENT = bundle.getString("com.alorma.github.sdk.client");
+            API_SECRET = bundle.getString("com.alorma.github.sdk.secret");
+            API_OAUTH = bundle.getString("com.alorma.github.sdk.oauth");
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e("GitHubSdk", "Failed to load meta-data, NameNotFound: " + e.getMessage());
+        } catch (NullPointerException e) {
+            Log.e("GitHubSdk", "Failed to load meta-data, NullPointer: " + e.getMessage());
+        }
+    }
+
     @Override
     public String getApiClient() {
-        return BuildConfig.CLIENT_ID;
+        return API_CLIENT;
     }
 
     @Override
     public String getAPiSecret() {
-        return BuildConfig.CLIENT_SECRET;
+        return API_SECRET;
     }
 
     @Override
     public String getApiOauth() {
-        return BuildConfig.CLIENT_CALLBACK;
+        return API_OAUTH;
     }
 
     @Override

--- a/src/main/java/com/alorma/github/sdk/services/client/GithubClient.java
+++ b/src/main/java/com/alorma/github/sdk/services/client/GithubClient.java
@@ -21,7 +21,7 @@ import retrofit.client.Response;
 public abstract class GithubClient<K>  extends BaseClient<K> {
 
 	public GithubClient(Context context) {
-		super(context, new GitHub());
+		super(context, new GitHub(context));
 	}
 
 	@Override

--- a/src/main/java/com/alorma/github/sdk/services/content/GetMarkdownClient.java
+++ b/src/main/java/com/alorma/github/sdk/services/content/GetMarkdownClient.java
@@ -42,9 +42,8 @@ public class GetMarkdownClient implements Callback<String>, Client {
     }
 
     public void execute() {
-
         RestAdapter restAdapter = new RestAdapter.Builder()
-                .setEndpoint(new GitHub().getApiEndpoint())
+                .setEndpoint(new GitHub(context).getApiEndpoint())
                 .setLogLevel(RestAdapter.LogLevel.HEADERS)
                 .setClient(this)
                 .build();


### PR DESCRIPTION
So using it is simple. The app which uses the lib adds the three meta-data tags to it's manifest file as follows:
```xml
 <application>
...
    <meta-data
        android:name="com.alorma.github.sdk.client"
        android:value="YOUR_CLIENT_ID_HERE"/>

    <meta-data
        android:name="com.alorma.github.sdk.secret"
        android:value="YOUR_SECRET_HERE"/>

    <meta-data
        android:name="com.alorma.github.sdk.oauth"
        android:value="YOUR_URL_HERE"/>
...
</application>
```
So the app can now be compile to .aar and use by anyone!
(PS We should either replace the BaseSdk thing i added or update BaseSdk to support JitPack)