### PR TITLE
remove deprecated api

### DIFF
--- a/src/main/java/com/alorma/github/sdk/services/git/GitDataService.java
+++ b/src/main/java/com/alorma/github/sdk/services/git/GitDataService.java
@@ -8,7 +8,6 @@ import com.alorma.github.sdk.bean.dto.response.GitTree;
 import java.util.List;
 
 import retrofit.Callback;
-import retrofit.http.EncodedPath;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;


### PR DESCRIPTION
I think could remove the import of  retrofit.http.EncodedPath